### PR TITLE
Fix GCC compiler warnings for Ruby build

### DIFF
--- a/c/ast.c
+++ b/c/ast.c
@@ -1,8 +1,9 @@
 #include "ast.h"
 #include "parser.h"
 #include "lexer.h"
+#include "unused.h"
 
-void yyerror(yyscan_t scanner, Node** node, const char* msg) {
+void yyerror(yyscan_t UNUSED(scanner), Node** UNUSED(node), const char* UNUSED(msg)) {
     //fprintf(stderr,"Error: %s\n", msg);
 }
  

--- a/c/unused.h
+++ b/c/unused.h
@@ -1,0 +1,11 @@
+#ifdef __GNUC__
+#  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+#else
+#  define UNUSED(x) UNUSED_ ## x
+#endif
+
+#ifdef __GNUC__
+#  define UNUSED_FUNCTION(x) __attribute__((__unused__)) UNUSED_ ## x
+#else
+#  define UNUSED_FUNCTION(x) UNUSED_ ## x
+#endif

--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -9,4 +9,5 @@ tmp
 ext/bool_ext/ast.*
 ext/bool_ext/lexer.*
 ext/bool_ext/parser.*
+ext/bool_ext/unused.*
 lib/bool_ext.so

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -30,7 +30,7 @@ else
   mingv_bin = File.expand_path('../../mingw/bin', __FILE__)
   ENV['PATH'] = "#{mingv_bin}:#{ENV['PATH']}"
 
-  %w[ast.h ast.c lexer.h lexer.c parser.h parser.c].each do |f|
+  %w[ast.h ast.c lexer.h lexer.c parser.h parser.c unused.h].each do |f|
     gen  = "../c/#{f}"
     copy = "ext/bool_ext/#{f}"
 


### PR DESCRIPTION
This commit fixes the warnings coming out of ast.c using
the fixes here:
http://stackoverflow.com/questions/3599160/unused-parameter-warnings-in-c-code

However I can't see how to fix the warnings coming from
lexer.c since it seems that code is auto-generated by
flex.

Any advance on this?
