### PR TITLE
Fix bundler security warning

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Replaced :rubygems with https://rubygems.org as recommended by Bundler output
