### PR TITLE
Switch to latest mingw-w64 to fix ruby-2.0.0-p0 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ mingw: mingw/bin/i686-w64-mingw32-gcc
 
 mingw/bin/i686-w64-mingw32-gcc:
 	mkdir -p mingw
-	# Don't attempt any of the newer versions - they don't work (gcc 4.7.0)
-	cd mingw && curl --silent --location http://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Automated%20Builds/mingw-w32-1.0-bin_i686-darwin_20110819.tar.bz2 | tar xvj
+	cd mingw && curl --silent --location http://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Automated%20Builds/mingw-w32-1.0-bin_i686-darwin_20120227.tar.bz2 | tar xvj
 endif
 
 ifeq ($(RUBY_PLATFORM), java)


### PR DESCRIPTION
Fixes a ruby-2.0.0-p0 issue. The reason for the removed comment isn't clear:
perhaps it used to fail when supporting 1.8.7?

Closes #40.
