### PR TITLE
Working token description lines

### DIFF
--- a/javascript/lib/lexer.l
+++ b/javascript/lib/lexer.l
@@ -3,13 +3,13 @@
 
 %%
 
-^\s+                  { /* skip leading whitespace */ }
-"Feature:"            { this.begin('AFTER_KEYWORD'); return 'TOKEN_FEATURE'; }
-"Given "|"When "      { this.begin('AFTER_KEYWORD'); return 'TOKEN_STEP'; }
-^(?:(?!Feature)).+    { return 'TOKEN_DESCRIPTION_LINE'; }
-<AFTER_KEYWORD>\s*    { /* skip whitespace after keyword */ this.begin('NAME'); }
-<NAME>.*              { this.begin('INITIAL'); return 'TOKEN_NAME'; }
-<<EOF>>               { return 'EOF'; }
+^\s+                                 { /* skip leading whitespace */ }
+"Feature:"                           { this.begin('AFTER_KEYWORD'); return 'TOKEN_FEATURE'; }
+^(?:(?!(Feature|Given|When|Then))).+ { return 'TOKEN_DESCRIPTION_LINE'; }
+"Given "|"When "|"Then "             { this.begin('AFTER_KEYWORD'); return 'TOKEN_STEP'; }
+<AFTER_KEYWORD>\s*                   { /* skip whitespace after keyword */ this.begin('NAME'); }
+<NAME>.*                             { this.begin('INITIAL'); return 'TOKEN_NAME'; }
+<<EOF>>                              { return 'EOF'; }
 
 %%
 

--- a/javascript/lib/lexer.l
+++ b/javascript/lib/lexer.l
@@ -1,12 +1,12 @@
 %x AFTER_KEYWORD
 %x NAME
-%x TOKEN_DESCRIPTION_LINE 
 
 %%
 
 ^\s+                  { /* skip leading whitespace */ }
 "Feature:"            { this.begin('AFTER_KEYWORD'); return 'TOKEN_FEATURE'; }
 "Given "|"When "      { this.begin('AFTER_KEYWORD'); return 'TOKEN_STEP'; }
+^(?:(?!Feature)).+    { return 'TOKEN_DESCRIPTION_LINE'; }
 <AFTER_KEYWORD>\s*    { /* skip whitespace after keyword */ this.begin('NAME'); }
 <NAME>.*              { this.begin('INITIAL'); return 'TOKEN_NAME'; }
 <<EOF>>               { return 'EOF'; }

--- a/javascript/test/lexer_test.js
+++ b/javascript/test/lexer_test.js
@@ -40,5 +40,14 @@ describe('Lexer', function() {
     assert.deepEqual([ 'TOKEN_DESCRIPTION_LINE', 'and so is this' ], lex());
   });
 
+  it ('tokenizes descriptions and given when then even when description is long', function() {
+    lexer.setInput("Feature:     description1\n  this is a longer description than the given step\n  Given a step");
+
+    assert.deepEqual([ 'TOKEN_FEATURE', 'Feature:' ], lex());
+    assert.deepEqual([ 'TOKEN_NAME', 'description1' ], lex());
+    assert.deepEqual([ 'TOKEN_DESCRIPTION_LINE', 'this is a longer description than the given step' ], lex());
+    assert.deepEqual([ 'TOKEN_STEP', 'Given ' ], lex());
+    assert.deepEqual([ 'TOKEN_NAME', 'a step' ], lex());
+  });
 });
 

--- a/javascript/test/lexer_test.js
+++ b/javascript/test/lexer_test.js
@@ -41,13 +41,29 @@ describe('Lexer', function() {
   });
 
   it ('tokenizes descriptions and given when then even when description is long', function() {
-    lexer.setInput("Feature:     description1\n  this is a longer description than the given step\n  Given a step");
+    lexer.setInput("Feature:     Hello\n  this is a longer description than the given step\n  Given a step");
 
     assert.deepEqual([ 'TOKEN_FEATURE', 'Feature:' ], lex());
-    assert.deepEqual([ 'TOKEN_NAME', 'description1' ], lex());
+    assert.deepEqual([ 'TOKEN_NAME', 'Hello' ], lex());
     assert.deepEqual([ 'TOKEN_DESCRIPTION_LINE', 'this is a longer description than the given step' ], lex());
     assert.deepEqual([ 'TOKEN_STEP', 'Given ' ], lex());
     assert.deepEqual([ 'TOKEN_NAME', 'a step' ], lex());
   });
+
+  it ('tokenizes descriptions and given/when/then when the steps are longer than the descriptions', function() {
+    lexer.setInput("Feature:     Hello\n  description\nmore\n  Given a reasonably long step\n  When I do something interesting\n  Then stuff happens");
+
+    assert.deepEqual([ 'TOKEN_FEATURE', 'Feature:' ], lex());
+    assert.deepEqual([ 'TOKEN_NAME', 'Hello' ], lex());
+    assert.deepEqual([ 'TOKEN_DESCRIPTION_LINE', 'description' ], lex());
+    assert.deepEqual([ 'TOKEN_DESCRIPTION_LINE', 'more' ], lex());
+    assert.deepEqual([ 'TOKEN_STEP', 'Given ' ], lex());
+    assert.deepEqual([ 'TOKEN_NAME', 'a reasonably long step' ], lex());
+    assert.deepEqual([ 'TOKEN_STEP', 'When ' ], lex());
+    assert.deepEqual([ 'TOKEN_NAME', 'I do something interesting' ], lex());
+    assert.deepEqual([ 'TOKEN_STEP', 'Then ' ], lex());
+    assert.deepEqual([ 'TOKEN_NAME', 'stuff happens' ], lex());
+  });
+
 });
 


### PR DESCRIPTION
Negative lookahead allows negated character groups. Should go some way
to addressing https://github.com/cucumber/gherkin3/issues/4
